### PR TITLE
Add psychologist booking features

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,4 +13,16 @@ export const routes: Routes = [
     path: 'intro2',
     loadComponent: () => import('./intro2/intro2.page').then( m => m.Intro2Page)
   },
+  {
+    path: 'psychologists',
+    loadComponent: () => import('./psychologists/psychologists.page').then(m => m.PsychologistsPage)
+  },
+  {
+    path: 'psychologists/:id',
+    loadComponent: () => import('./psychologist-detail/psychologist-detail.page').then(m => m.PsychologistDetailPage)
+  },
+  {
+    path: 'tests',
+    loadComponent: () => import('./tests/tests.page').then(m => m.TestsPage)
+  },
 ];

--- a/src/app/intro2/intro2.page.ts
+++ b/src/app/intro2/intro2.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicSlides } from '@ionic/angular';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -15,11 +15,7 @@ register();
   schemas: [CUSTOM_ELEMENTS_SCHEMA],  // Add this to avoid errors with web components
 })
 
-export class Intro2Page implements OnInit {
+export class Intro2Page {
   swiperModules = [IonicSlides];
   constructor() { }
-
-  ngOnInit() {
-  }
-
 }

--- a/src/app/psychologist-detail/psychologist-detail.page.html
+++ b/src/app/psychologist-detail/psychologist-detail.page.html
@@ -1,0 +1,18 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>{{psychologist?.name}}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content *ngIf="psychologist">
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>{{psychologist.name}}</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p>{{psychologist.specialization}}</p>
+      <p>{{psychologist.description}}</p>
+    </ion-card-content>
+  </ion-card>
+  <ion-button expand="block" (click)="book()">Book Session</ion-button>
+</ion-content>

--- a/src/app/psychologist-detail/psychologist-detail.page.scss
+++ b/src/app/psychologist-detail/psychologist-detail.page.scss
@@ -1,0 +1,1 @@
+/* Style for detail page */

--- a/src/app/psychologist-detail/psychologist-detail.page.spec.ts
+++ b/src/app/psychologist-detail/psychologist-detail.page.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { PsychologistDetailPage } from './psychologist-detail.page';
+import { PsychologistService } from '../services/psychologist.service';
+
+describe('PsychologistDetailPage', () => {
+  let component: PsychologistDetailPage;
+  let fixture: ComponentFixture<PsychologistDetailPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [PsychologistDetailPage, HttpClientTestingModule],
+      providers: [PsychologistService, { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PsychologistDetailPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/psychologist-detail/psychologist-detail.page.ts
+++ b/src/app/psychologist-detail/psychologist-detail.page.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { IONIC_STANDALONE_IMPORTS } from '../ionic-standalone-imports';
+import { PsychologistService, Psychologist, SessionRequest } from '../services/psychologist.service';
+
+@Component({
+  selector: 'app-psychologist-detail',
+  templateUrl: './psychologist-detail.page.html',
+  styleUrls: ['./psychologist-detail.page.scss'],
+  standalone: true,
+  imports: [...IONIC_STANDALONE_IMPORTS, CommonModule]
+})
+export class PsychologistDetailPage {
+  psychologist?: Psychologist;
+
+  constructor(private route: ActivatedRoute, private service: PsychologistService) {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (id) {
+      this.service.getPsychologist(id).subscribe(p => this.psychologist = p);
+    }
+  }
+
+  book() {
+    if (!this.psychologist) return;
+    const req: SessionRequest = { psychologistId: this.psychologist.id, date: new Date().toISOString() };
+    this.service.bookSession(req).subscribe();
+  }
+}

--- a/src/app/psychologists/psychologists.page.html
+++ b/src/app/psychologists/psychologists.page.html
@@ -1,0 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Psychologists</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-item>
+    <ion-input placeholder="Search" [(ngModel)]="search" (ionInput)="filter()"></ion-input>
+  </ion-item>
+  <ion-list>
+    <ion-item button *ngFor="let p of filtered" (click)="open(p)">
+      <ion-label>
+        <h2>{{p.name}}</h2>
+        <p>{{p.specialization}}</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/psychologists/psychologists.page.scss
+++ b/src/app/psychologists/psychologists.page.scss
@@ -1,0 +1,1 @@
+/* Styles for psychologist list */

--- a/src/app/psychologists/psychologists.page.spec.ts
+++ b/src/app/psychologists/psychologists.page.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PsychologistsPage } from './psychologists.page';
+import { PsychologistService } from '../services/psychologist.service';
+
+describe('PsychologistsPage', () => {
+  let component: PsychologistsPage;
+  let fixture: ComponentFixture<PsychologistsPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [PsychologistsPage, HttpClientTestingModule],
+      providers: [PsychologistService]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PsychologistsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/psychologists/psychologists.page.ts
+++ b/src/app/psychologists/psychologists.page.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { IONIC_STANDALONE_IMPORTS } from '../ionic-standalone-imports';
+import { Psychologist, PsychologistService } from '../services/psychologist.service';
+
+@Component({
+  selector: 'app-psychologists',
+  templateUrl: './psychologists.page.html',
+  styleUrls: ['./psychologists.page.scss'],
+  standalone: true,
+  imports: [...IONIC_STANDALONE_IMPORTS, CommonModule, FormsModule]
+})
+export class PsychologistsPage {
+  psychologists: Psychologist[] = [];
+  filtered: Psychologist[] = [];
+  search = '';
+
+  constructor(private service: PsychologistService, private router: Router) {
+    this.load();
+  }
+
+  load() {
+    this.service.getPsychologists().subscribe((data) => {
+      this.psychologists = data;
+      this.filter();
+    });
+  }
+
+  filter() {
+    const term = this.search.toLowerCase();
+    this.filtered = this.psychologists.filter(p => p.name.toLowerCase().includes(term));
+  }
+
+  open(p: Psychologist) {
+    this.router.navigate(['/psychologists', p.id]);
+  }
+}

--- a/src/app/services/psychologist.service.ts
+++ b/src/app/services/psychologist.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Psychologist {
+  id: number;
+  name: string;
+  specialization: string;
+  description: string;
+}
+
+export interface SessionRequest {
+  psychologistId: number;
+  date: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PsychologistService {
+  private apiUrl = 'https://example.com/api';
+
+  constructor(private http: HttpClient) {}
+
+  getPsychologists(): Observable<Psychologist[]> {
+    return this.http.get<Psychologist[]>(`${this.apiUrl}/psychologists`);
+  }
+
+  getPsychologist(id: number): Observable<Psychologist> {
+    return this.http.get<Psychologist>(`${this.apiUrl}/psychologists/${id}`);
+  }
+
+  bookSession(request: SessionRequest): Observable<any> {
+    return this.http.post(`${this.apiUrl}/sessions`, request);
+  }
+}

--- a/src/app/tests/tests.page.html
+++ b/src/app/tests/tests.page.html
@@ -1,0 +1,10 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Test</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <p>Take a quick test to find your psychologist.</p>
+  <ion-button expand="block" (click)="start()">Start Test</ion-button>
+</ion-content>

--- a/src/app/tests/tests.page.scss
+++ b/src/app/tests/tests.page.scss
@@ -1,0 +1,1 @@
+/* Styles for tests page */

--- a/src/app/tests/tests.page.spec.ts
+++ b/src/app/tests/tests.page.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestsPage } from './tests.page';
+
+describe('TestsPage', () => {
+  let component: TestsPage;
+  let fixture: ComponentFixture<TestsPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestsPage]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tests/tests.page.ts
+++ b/src/app/tests/tests.page.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { IONIC_STANDALONE_IMPORTS } from '../ionic-standalone-imports';
+
+@Component({
+  selector: 'app-tests',
+  templateUrl: './tests.page.html',
+  styleUrls: ['./tests.page.scss'],
+  standalone: true,
+  imports: [...IONIC_STANDALONE_IMPORTS, CommonModule]
+})
+export class TestsPage {
+  constructor(private router: Router) {}
+
+  start() {
+    this.router.navigate(['/psychologists']);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -10,5 +11,6 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideHttpClient(),
   ],
 });


### PR DESCRIPTION
## Summary
- add PsychologistService for API calls
- add pages to list psychologists, view detail, and test chooser
- wire up routes and HTTP client provider
- fix linter issue in Intro2 page

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684aaeb1a2a0832897201208906c1cec